### PR TITLE
Implement login to save the context and add validations for search tests

### DIFF
--- a/src/lib/login.test.ts
+++ b/src/lib/login.test.ts
@@ -12,5 +12,13 @@ test('Sign in to Wikipedia and save storage state', async ({ page, context }) =>
     throw new Error('Need a username and password to sign in!');
   }
 
- // await context.storageState({ path: authFile });
+  await page.goto('https://auth.wikimedia.org/enwiki/wiki/Special:UserLogin');
+  const emailInput = page.getByPlaceholder('Enter your username');
+  await emailInput.fill(wikipediaUsername);
+  const passwordInput = page.getByPlaceholder('Enter your password');
+  await passwordInput.fill(wikipediaPassword);
+
+  await page.getByRole('button', {name: 'Log in'}).click();
+  
+  await context.storageState({ path: authFile });
 });

--- a/src/lib/tests/searchWikipedia.ts
+++ b/src/lib/tests/searchWikipedia.ts
@@ -11,23 +11,40 @@ import { Page, expect } from '@playwright/test';
  */
 
 export async function run(page: Page, params: {}) {
-
-    const searchInput = page.getByRole('searchbox', { name: 'Search Wikipedia' });
-
     // 1
     await page.goto('https://www.wikipedia.org/');
 
     // 2
-    await searchInput.fill('artificial');
-        
-    // 3
-    const artificialIntelligenceLink = page.getByRole('link', {
-        name: 'Artificial intelligence',
+    const searchInput = page.getByRole('searchbox', {
+        name: 'Search Wikipedia',
     });
-    await artificialIntelligenceLink.click();;
+    await searchInput.fill('artificial');
 
-    // 4. 
+    // 3
+    const artificialIntelligenceLink = page
+        .getByRole('link')
+        .filter({ hasText: 'Artificial intelligence' })
+        .first();
+    await artificialIntelligenceLink.click();
+
+    // 4.
+
+    const header = page
+        .getByRole('heading')
+        .getByText('Artificial intelligence')
+        .first();
+
+    await expect(header).toBeVisible();
+
+    const viewHistoryButton = page.getByTitle(
+        'Past revisions of this page [alt-shift-h]',
+    );
+    await viewHistoryButton.click();
 
     // 5.
 
+    const lastUpdate = page.locator('[class*="contributions-list"] li').first();
+    await expect(
+        lastUpdate.getByTitle('User:ElegantEgotist (page does not exist)'),
+    ).toBeVisible();
 }

--- a/src/lib/tests/wikipediaHomepageActions.ts
+++ b/src/lib/tests/wikipediaHomepageActions.ts
@@ -12,26 +12,45 @@ test.use({ storageState: 'src/auth/login.json' });
  */
 
 export async function run(page: Page, params: {}) {
-  // 1
-  await page.goto('https://en.wikipedia.org/wiki/Main_Page');
+    // 1
+    await page.goto('https://en.wikipedia.org/wiki/Main_Page');
 
-  // 2.
-  const countLink = page.getByRole('link', { name: /^\d{1,3}(,\d{3})*$/ });
-  const raw = await countLink.innerText();
+    // 2.
+    const countLink = page
+        .getByRole('link', { name: /^\d{1,3}(,\d{3})*$/ })
+        .last();
+    const raw = await countLink.innerText();
+    await expect(Number(raw.replace(/,/g, ''))).toBeLessThan(7000000);
 
-  // 3–5.
+    // 3–5.
 
+    // Small
 
-  // Small
+    const smallSizeButton = page.getByRole('radio', { name: 'Small' });
+    await smallSizeButton.click();
+    const header = page.getByRole('heading').getByText('Welcome to ').first();
 
+    await expect(header).toHaveCSS('font-size', '22.68px');
 
-  // Large
+    // Large
 
+    const largeSizeButton = page.getByRole('radio', { name: 'Large' });
+    await largeSizeButton.click();
 
-  // Standard
+    await expect(header).toHaveCSS('font-size', '32.4px');
 
+    // Standard
+
+    const standardSizeButton = page
+        .getByRole('radio', { name: 'Standard' })
+        .first();
+    await standardSizeButton.click();
+
+    await expect(header).toHaveCSS('font-size', '25.92px');
 }
 
-test('Perform Wikipedia homepage actions and validate counts & text‑size', async ({ page }) => {
-  await run(page, {});
+test('Perform Wikipedia homepage actions and validate counts & text‑size', async ({
+    page,
+}) => {
+    await run(page, {});
 });


### PR DESCRIPTION
1. Completes the login implementation to save the session context, which is then used in the rest of the tests.
2. In the search tests:
- searchWikipedia.ts: Adds the "Artificial intelligence" option to validate the last update in the history.
- wikipediaHomepageActions.ts: Adds validation of the number of published articles and sources for the different appearance configurations.

![image](https://github.com/user-attachments/assets/498d5454-9c02-4dad-ab56-a58a354f76fe)
